### PR TITLE
Load different .env based upon RACK_ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env.development
+.env.test

--- a/gossyp.rb
+++ b/gossyp.rb
@@ -1,4 +1,7 @@
 $LOAD_PATH.unshift(File.expand_path('.'))
+
+# Default the RACK_ENV to development unless it's explicitely specified
+ENV['RACK_ENV'] ||= 'development'
 require 'sinatra'
 # Omniauth requires cookies so it can store data across page requests
 enable :sessions

--- a/initializers/dotenv.rb
+++ b/initializers/dotenv.rb
@@ -13,6 +13,6 @@ unless ["production", "staging"].include? ENV['RACK_ENV']
   # This makes it easy to keep our secret configuration variables
   # outside of our public repo. HOORAY!
   require 'dotenv'
-  Dotenv.load('.env.development')
+  Dotenv.load(".env.#{ENV['RACK_ENV']}")
   # https://github.com/bkeepers/dotenv#sinatra-or-plain-ol-ruby
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,8 @@ $LOAD_PATH.unshift(File.expand_path('.'))
 # $LOAD_PATH - http://www.ruby-doc.org/core-2.0/Kernel.html#method-i-require
 # Array#unshift http://www.ruby-doc.org/core-2.0.0/Array.html#method-i-unshift
 
-# We require our app so that we have access to Sinatra::Application for capybara
+# Default RACK_ENV to test when we're running specs
+ENV['RACK_ENV'] ||= 'test'
 require 'gossyp'
 
 require 'capybara/rspec'


### PR DESCRIPTION
This allows us to specify different database urls in our
.env files, instead of branching in our code.
