### PR TITLE
Gossyper may see gossyp

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,3 @@
-$LOAD_PATH.unshift('.')
-require 'gossyp'
-require 'sinatra/activerecord/rake'
 
 unless ['production', 'staging'].include? ENV['RACK_ENV']
   require 'rspec/core/rake_task'
@@ -19,3 +16,17 @@ unless ['production', 'staging'].include? ENV['RACK_ENV']
   end
   task :default => "spec:all"
 end
+
+task :environment do
+  $LOAD_PATH.unshift('.')
+  require 'gossyp'
+end
+
+require 'sinatra/activerecord/rake'
+
+# Ensure that we load the environment before doing database stuff
+["db:migrate", "db:rollback", "db:schema:dump", "db:schema:load"].each do |task|
+  Rake::Task[task].enhance [:environment]
+end
+
+# See: http://www.dan-manges.com/blog/modifying-rake-tasks

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,10 @@
-## SMURF 1 - lolwat
-
-### Done
-* Guest may login with twitter
-* Gossyper may create a public gossyp with title and body
-
 ### Next
-* Gossyper may see all discussion titles, with most recent at the
-  top
-* Gossyper may see a discussion
 * Gossyper may respond to a discussion
 * Gossyper may see responses to a discussion
+* Gossyper may log out
+
+### Done - Most recent at top
+* Gossyper may see a gossyp thread
+* Gossyper may see all gossyp titles
+* Gossyper may create a public gossyp with title and body
+* Guest may login with twitter

--- a/spec/features/gossyper_may_create_discussion_feature.rb
+++ b/spec/features/gossyper_may_create_discussion_feature.rb
@@ -1,22 +1,6 @@
 require 'spec_helper'
 
 describe "Gossyper may creete discussion", type: :feature do
-  def create_gossyper
-    require 'securerandom'
-    User.create({
-      twitter_uid: 1234,
-      full_name: "Gossyper #{SecureRandom.hex(4)}"
-    })
-  end
-
-  def login_as(user)
-    OmniAuth.config.add_mock(:twitter, {
-      uid: user.twitter_uid,
-      :info => { :name => user.full_name }
-    })
-
-    visit '/auth/twitter'
-  end
   context "when logged in" do
     let(:gossyper) { create_gossyper  }
     context "when gossyper provides all required fields" do
@@ -54,7 +38,7 @@ describe "Gossyper may creete discussion", type: :feature do
   context "when not logged in" do
     it "does not allow a gossyper to create a discussion" do
       visit '/gossyps/new'
-      expect(current_url).to eql 'http://www.example.com/'
+      expect(page.status_code).to eql 403
     end
   end
 end

--- a/spec/features/gossyper_may_see_gossyp_feature.rb
+++ b/spec/features/gossyper_may_see_gossyp_feature.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe "Gossyper may view gossyp", type: :feature do
+  let!(:gossyps) {
+    3.times.map do
+      create_random_gossyp
+    end
+  }
+  # I'm using let! because I want to ensure this code gets ran immediately
+  context "when logged in" do
+    before do
+      login_as(create_gossyper)
+      visit '/'
+    end
+    it "shows all the gossyps titles on the home page" do
+      gossyps.each do |gossyp|
+        expect(page).to have_content(gossyp.title)
+      end
+    end
+    it "shows the gossyp body on the gossyp show page" do
+      gossyp = gossyps.pop
+      click_on gossyp.title
+      expect(page).to have_content(gossyp.body)
+    end
+  end
+
+  context "when not logged in" do
+    it "shows no gossyp on the home page" do
+      visit '/'
+
+      gossyps.each do |gossyp|
+        expect(page).not_to have_content(gossyp.title)
+      end
+    end
+    it "prevents guests from even visiting a gossyp show page" do
+      gossyp = gossyps.pop
+      visit "/gossyps/#{gossyp.id}"
+      expect(page.status_code).to eq 403
+      expect(page).not_to have_content(gossyp.title)
+      expect(page).not_to have_content(gossyp.body)
+    end
+  end
+end

--- a/spec/helpers/feature_login_helper.rb
+++ b/spec/helpers/feature_login_helper.rb
@@ -1,0 +1,10 @@
+module FeatureLoginHelper
+  def login_as(user)
+    OmniAuth.config.add_mock(:twitter, {
+      uid: user.twitter_uid,
+      :info => { :name => user.full_name }
+    })
+
+    visit '/auth/twitter'
+  end
+end

--- a/spec/helpers/test_fixture_helper.rb
+++ b/spec/helpers/test_fixture_helper.rb
@@ -1,0 +1,16 @@
+require 'securerandom'
+module TestFixturesHelper
+  def create_gossyper
+    User.create({
+      twitter_uid: 1234,
+      full_name: "Gossyper #{SecureRandom.hex(4)}"
+    })
+  end
+
+  def create_random_gossyp
+    Gossyp.create({
+      title: "Gossyp #{SecureRandom.hex(4)}",
+      body: "Gossyp Body #{SecureRandom.hex(4)}"
+    })
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ ENV['RACK_ENV'] ||= 'test'
 require 'gossyp'
 
 require 'capybara/rspec'
+require 'helpers/test_fixture_helper'
+require 'helpers/feature_login_helper'
 
 # Tell capybara that we're testing your sinatra app
 # https://github.com/jnicklas/capybara#setup
@@ -25,5 +27,17 @@ ActiveRecord::Base.logger = Logger.new('/dev/null')
 RSpec.configure do |config|
   config.before do
     User.destroy_all
+    Gossyp.destroy_all
   end
+
+  # This makes sure that we include the TestFixturesHelper in all of our tests
+  # Making the helper functions available to everyone!
+  config.include TestFixturesHelper
+
+  # This makes sure we include the FeatureLoginHelper only in tests that we tag
+  # with feature.
+  config.include FeatureLoginHelper, :type => :feature
+
+  # See: https://www.relishapp.com/rspec/rspec-core/v/2-14/docs/helper-methods/define-helper-methods-in-a-module
+  # For the official docs on how to include helpers
 end

--- a/views/forbidden.erb
+++ b/views/forbidden.erb
@@ -1,0 +1,2 @@
+<h1>Woah There CowPerson</h1>
+<p>Ya ain't allowed to do that.</p>

--- a/views/home.erb
+++ b/views/home.erb
@@ -6,3 +6,6 @@
 </ul>
 </nav>
 
+<% @gossyps.each do |gossyp| %>
+  <h3><a href="/gossyps/<%=gossyp.id%>"><%=gossyp.title%></a></h3>
+<% end %>

--- a/views/show_gossyp.erb
+++ b/views/show_gossyp.erb
@@ -1,0 +1,2 @@
+<h2><%= @gossyp.title %></h2>
+<p><%= @gossyp.body %></p>


### PR DESCRIPTION
Outline Gossyper May See Gossyp feature
Write feature for Gossyp viewing list of gossyp
Show all titles for gossyp on the home page
Fix rake to not set RACK_ENV to development
Gossyps may be shown
Destroy all Gossyps after each test run
Don't show gossyp index to non logged in users
Prevent guests from viewing gossyp pages
Extract filter to protect  gossyps routes
Move Gossyper may see all/specific gossyp to done
## [Commit By Commit Breakdown](https://github.com/tiger-swallowtails-2013/gossyp/compare/gossyper-may-see-gossyp-titles)
