### PR TITLE
Gossyper may star and unstar gossyp

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,9 @@
 ### Next
-* Gossyper may star gossyp
 * Gossyper may star gossyp without reloading the page
 * Gossyper may add more more gossyp without reloading the page
 
 ### Done - Most recent at top
+* Gossyper may star gossyp
 * Gossyper may log out
 * Gossyper may see reactions  to a discussion
 * Gossyper may react to a discussion

--- a/db/migrate/20131004181011_create_stars.rb
+++ b/db/migrate/20131004181011_create_stars.rb
@@ -1,0 +1,13 @@
+class CreateStars < ActiveRecord::Migration
+  def up
+    create_table :stars do |t|
+      t.belongs_to :user
+      t.belongs_to :gossyp
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :stars
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131001221905) do
+ActiveRecord::Schema.define(version: 20131004181011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,13 @@ ActiveRecord::Schema.define(version: 20131001221905) do
     t.integer  "gossyp_id"
     t.integer  "user_id"
     t.text     "body"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "stars", force: true do |t|
+    t.integer  "user_id"
+    t.integer  "gossyp_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/helpers.rb
+++ b/helpers.rb
@@ -19,4 +19,12 @@ helpers do
   def logout!
     session[:user_id] = nil
   end
+
+  def starred_message(gossyp)
+    gossyp.starred_by?(current_user) ? "starred" : "unstarred"
+  end
+
+  def star_button_text(gossyp)
+    gossyp.starred_by?(current_user) ? "Unstar" : "Star"
+  end
 end

--- a/models.rb
+++ b/models.rb
@@ -1,12 +1,27 @@
 class Gossyp < ActiveRecord::Base
   has_many :reactions
+  has_many :stars
 
   validates :title, :presence => true
   validates :body, :presence => true
+
+  def toggle_star! gossyper
+    if starred_by? gossyper
+      stars.find_by(user_id: gossyper.id).destroy
+    else
+      stars.create(user_id: gossyper.id)
+    end
+  end
+
+  def starred_by? gossyper
+    stars.where(user_id: gossyper.id).exists?
+  end
 end
 
 class User < ActiveRecord::Base
   has_many :gossyps
+  has_many :stars
+
   def self.from_auth_hash(auth_hash)
     user = User.find_or_create_by(twitter_uid: auth_hash[:uid])
     user.update_attributes(full_name: auth_hash[:info][:name])
@@ -19,4 +34,7 @@ class Reaction < ActiveRecord::Base
   belongs_to :gossyp
 
   validates :body, :presence => true
+end
+
+class Star < ActiveRecord::Base
 end

--- a/routes.rb
+++ b/routes.rb
@@ -32,21 +32,30 @@ before '/gossyps*' do
     # http://www.sinatrarb.com/intro.html#Halting
   end
 end
+
 get '/gossyps/new' do
   @gossyp = Gossyp.new
   erb :new_gossyp
 end
 
+before %r{\/gossyps\/(\d+)} do
+  @gossyp = Gossyp.find(params[:captures].first)
+end
+
 get '/gossyps/:id' do
-  @gossyp = Gossyp.find(params[:id])
   @reaction = Reaction.new
   erb :show_gossyp
 end
 
 post '/gossyps/:id/reactions' do
-  @gossyp = Gossyp.find(params[:id])
   @reaction = @gossyp.reactions.create(params[:reaction])
   erb :show_gossyp
+end
+
+post '/gossyps/:id/stars' do
+  @gossyp.toggle_star!(current_user)
+  flash[:notice] = "You've #{starred_message(@gossyp)} #{@gossyp.title}!"
+  redirect '/'
 end
 
 post '/gossyps' do

--- a/spec/features/gossyper_may_star_gossyp_feature.rb
+++ b/spec/features/gossyper_may_star_gossyp_feature.rb
@@ -1,0 +1,34 @@
+describe 'Gossyper may star gossyp', type: :feature do
+  context "when the gossyp is not yet starred" do
+    it "stars the gossyp!" do
+      gossyper = create_gossyper
+      gossyp = create_random_gossyp
+      login_as gossyper
+
+      click_on "star_gossyp_#{gossyp.id}"
+
+      expect(page).to have_content "You've starred #{gossyp.title}!"
+
+      within "#gossyp_#{gossyp.id}" do
+        expect(page).to have_button "Unstar"
+      end
+    end
+  end
+
+  context "when the gossyp is starred" do
+    it "unstars the gossyp" do
+      gossyper = create_gossyper
+      gossyp = create_random_gossyp
+      gossyp.toggle_star!(gossyper)
+
+      login_as gossyper
+
+      click_on "star_gossyp_#{gossyp.id}"
+      expect(page).to have_content "You've unstarred #{gossyp.title}!"
+
+      within "#gossyp_#{gossyp.id}" do
+        expect(page).to have_button "Star"
+      end
+    end
+  end
+end

--- a/spec/integration/gossyp_spec.rb
+++ b/spec/integration/gossyp_spec.rb
@@ -4,4 +4,29 @@ describe Gossyp do
   it { should have_many :reactions }
   it { should validate_presence_of(:title) }
   it { should validate_presence_of(:body) }
+
+  describe "#toggle_star!" do
+    context "when the user has not yet starred the gossyp" do
+      it "adds a star" do
+
+        gossyper = create_gossyper
+        gossyp = create_random_gossyp
+        gossyp.toggle_star! gossyper
+
+        expect(gossyp).to be_starred_by gossyper
+      end
+    end
+    context "when the user has already starred the gossyp" do
+      it "removes the star" do
+
+        gossyper = create_gossyper
+        gossyp = create_random_gossyp
+        gossyp.toggle_star! gossyper
+        gossyp.toggle_star! gossyper
+
+        expect(gossyp).not_to be_starred_by gossyper
+      end
+    end
+
+  end
 end

--- a/views/home.erb
+++ b/views/home.erb
@@ -11,5 +11,10 @@
 </nav>
 
 <% @gossyps.each do |gossyp| %>
-  <h3><a href="/gossyps/<%=gossyp.id%>"><%=gossyp.title%></a></h3>
+  <div id="gossyp_<%=gossyp.id%>">
+    <h3><a href="/gossyps/<%=gossyp.id%>"><%=gossyp.title%></a></h3>
+    <form method="post" action="/gossyps/<%=gossyp.id%>/stars"><input
+      type="submit" id="star_gossyp_<%=gossyp.id%>" value="<%= star_button_text(gossyp) %>" />
+    </form>
+  </div>
 <% end %>


### PR DESCRIPTION
I decided to place the check to see if a piece of gossyp had been starred onto
the gossyp, because making changes across multiple classes when you don't need
to should be avoided.

I considered placing the message for starring on the Gossyp model; but that
would conflate presentation logic with data logic; so I put it in a helper.
- Extract a before filter to load gossyp

I noticed quite a few `Gossyp.find` calls in my routes; so I hit Rubular.com
and wrote a regular expression to find the right Gossyp for the routes with a
gossyp_id

This article helped me bunches:
http://stackoverflow.com/questions/12375820/how-to-match-regex-route-in-sinatra
## [Commit By Commit Breakdown](https://github.com/tiger-swallowtails-2013/gossyp/compare/gossyper-may-star-gossyp)
